### PR TITLE
Fix broken Getting Started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each incoming http request is sandboxed in a single deno subprocess by the small
 
 ## Installation
 
-All the instructions are written in the [getting started guide](https://pomdtr.github.io/smallweb).
+All the instructions are written in the [getting started guide](https://smallweb-docs.pomdtr.me/).
 
 ## Demo
 


### PR DESCRIPTION
The old "Getting Started" link on the README was resulting in a not found. Please correct the link if this is not the right one