### PR TITLE
Docs: corrected JSX pragma in Hono documentation

### DIFF
--- a/docs/src/guides/hono.md
+++ b/docs/src/guides/hono.md
@@ -126,7 +126,7 @@ For the above code, it will work well with the following directory structure.
 If you want to return html from your endpoint, hono comes with built-in support for JSX.
 
 ```jsx
-// @jsxImportSource jsr:@hono/hono/jsx
+/** @jsxImportSource jsr:@hono/hono/jsx */
 
 import { Hono } from 'jsr:@hono/hono'
 


### PR DESCRIPTION
Changes the JSX pragma at the top of the code snippet of the [JSX Support section](https://smallweb-docs.pomdtr.me/guides/hono.html?highlight=jsx#jsx-support) of the docs.