### PR TITLE
fixes Mac OS docs for Homebrew on intel vs silicon

### DIFF
--- a/docs/src/hosting/localhost/localhost.md
+++ b/docs/src/hosting/localhost/localhost.md
@@ -42,8 +42,18 @@ smallweb service install
 
 ### Setup Caddy {#setup-caddy-macos}
 
+Caddy’s configuration path depends on whether you're using an Intel-based Mac or an Apple Silicon (M1/M2) Mac. 
+
+- **For Apple Silicon (M1/M2) Macs**:
+  The default installation path is `/opt/homebrew/etc/Caddyfile`.
+- **For Intel-based Macs**:
+  The default installation path is `/usr/local/etc/Caddyfile`.
+
+#### Apple Silicon (M1/M2):
+
 ```sh
 brew install caddy
+
 # Write caddy configuration
 cat <<EOF > /opt/homebrew/etc/Caddyfile
 *.localhost {
@@ -54,7 +64,28 @@ cat <<EOF > /opt/homebrew/etc/Caddyfile
   reverse_proxy localhost:7777
 }
 EOF
+```
 
+#### Intel-based:
+
+```sh
+brew install caddy
+
+# Write caddy configuration
+cat <<EOF > /usr/local/etc/Caddyfile
+*.localhost {
+  tls internal {
+    on_demand
+  }
+
+  reverse_proxy localhost:7777
+}
+EOF
+```
+
+#### Run Caddy:
+
+```sh
 # Run caddy in the background
 brew services start caddy
 
@@ -62,14 +93,31 @@ brew services start caddy
 caddy trust
 ```
 
-### Setup dnsmasq
+### Setup dnsmasq {#setup-dnsmasq-macos}
+
+The configuration path for dnsmasq also depends on your Mac's architecture.
+
+#### Apple Silicon (M1/M2):
 
 ```sh
 brew install dnsmasq
 
 # Write dnsmasq configuration
 echo "address=/.localhost/127.0.0.1" >> /opt/homebrew/etc/dnsmasq.conf
+```
 
+#### Intel-based:
+
+```sh
+brew install dnsmasq
+
+# Write dnsmasq configuration
+echo "address=/.localhost/127.0.0.1" >> /usr/local/etc/dnsmasq.conf
+```
+
+#### Run dnsmasq:
+
+```sh
 # Run dnsmasq in the background
 sudo brew services start dnsmasq
 


### PR DESCRIPTION
On M1/M2 homebrew installs itself in /opt/homebrew/ by default, intel-based installs itself to /usr/local/ by default.

This pull request adds the two pathways for both caddy and dnsmasq