### PR TITLE
Feat: Add docker job for building docker images of smallweb

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: release
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get tag without v prefix
+        id: tag
+        run: echo "name=${${{ github.ref }}#v}" >> $GITHUB_OUTPUT
       # Use this for dockerhub
       # - uses: docker/login-action@v3
       #   with:
@@ -54,4 +57,4 @@ jobs:
           context: .
           push: true
           platforms: linux/arm64, linux/amd64
-          tags: ghcr.io/${{ github.repository_owner }}/smallweb:${{ github.ref_name }}, ghcr.io/${{ github.repository_owner }}/smallweb:latest # Include pomdtr/smallweb:${{ github.ref_name }}, pomdtr/smallweb:latest for dockerhub
+          tags: ghcr.io/${{ github.repository_owner }}/smallweb:${{ steps.tag.outputs.name }}, ghcr.io/${{ github.repository_owner }}/smallweb:latest # Include pomdtr/smallweb:${{ steps.tag.outputs.name }}, pomdtr/smallweb:latest for dockerhub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,3 +32,26 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Use this for dockerhub
+      # - uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ vars.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64, linux/amd64
+          tags: ghcr.io/${{ github.repository_owner }}/smallweb:${{ github.ref_name }}, ghcr.io/${{ github.repository_owner }}/smallweb:latest # Include pomdtr/smallweb:${{ github.ref_name }}, pomdtr/smallweb:latest for dockerhub


### PR DESCRIPTION
Just added a docker job that builds and pushes the smallweb docker image on the Github Container Registry. I also added some comments to enable Docker Hub too if you would like to.