### PR TITLE
Less confusing wording for logs

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -266,9 +266,9 @@ func NewCmdLogs() *cobra.Command {
 	cmd.Flags().StringVar(&flags.template, "template", "", "output logs using a Go template")
 	cmd.Flags().StringVar(&flags.remote, "remote", "", "ssh remote")
 	_ = cmd.RegisterFlagCompletionFunc("app", completeApp)
-	cmd.Flags().StringVar(&flags.logType, "type", "http", "log type")
+	cmd.Flags().StringVar(&flags.logType, "type", "http", "log type (http, console)")
 	_ = cmd.RegisterFlagCompletionFunc("type", cobra.FixedCompletions([]string{"http", "console"}, cobra.ShellCompDirectiveNoFileComp))
-	cmd.Flags().BoolVar(&flags.all, "all", false, "show all logs")
+	cmd.Flags().BoolVar(&flags.all, "all", false, "show logs for all apps")
 
 	return cmd
 }


### PR DESCRIPTION
Atm logs help message is very misleading
```
smallweb logs chatcraft --type console --help
View app logs

Usage:
  smallweb logs [app] [flags]

Aliases:
  logs, log

Flags:
      --all               show all logs
  -h, --help              help for logs
      --remote string     ssh remote
      --template string   output logs using a Go template
      --type string       log type (default "http")

Global Flags:
      --dir string   The root directory for smallweb
```
All to me means console and http :) but unfortunately you meant all apps.. console log type isn't even documented