### PR TITLE
refactor: remove www redirect

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -437,7 +437,7 @@ func (me *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func lookupApp(domain string) (app string, redirect bool, found bool) {
 	if domain == k.String("domain") {
-		return "www", true, true
+		return "www", false, true
 	}
 
 	for _, app := range k.MapKeys("apps") {
@@ -452,7 +452,7 @@ func lookupApp(domain string) (app string, redirect bool, found bool) {
 
 	for _, additionalDomain := range k.Strings("additionalDomains") {
 		if domain == additionalDomain {
-			return "www", true, true
+			return "www", false, true
 		}
 
 		if strings.HasSuffix(domain, fmt.Sprintf(".%s", additionalDomain)) {


### PR DESCRIPTION
By removing the redirect the `www` directory can work for both `example.com` and `www.example.com` which should be the intended behavior for when hosting a website.